### PR TITLE
Add --ignore-installed so get-pip.py doesn't fail

### DIFF
--- a/recipes/pip.rb
+++ b/recipes/pip.rb
@@ -44,7 +44,7 @@ execute "install-pip" do
   # Command updated to only allow pip versions prior to 8.0.0
   # @see https://github.com/DataDog/devops/issues/4225
   command <<-EOF
-  #{node['python']['binary']} get-pip.py 'pip<8'
+  #{node['python']['binary']} get-pip.py --ignore-installed 'pip<8'
   EOF
   not_if { ::File.exists?(pip_binary) }
 end


### PR DESCRIPTION
`get-pip.py` step has been failing on trying to upgrade an old version of `six`, installed through `distutils` by some other package. Adding [`--ignore-installed`](https://pip.pypa.io/en/stable/reference/pip_install/#cmdoption-I) should fix that.