### PR TITLE
Do not install setuptools on get-pip.py

### DIFF
--- a/recipes/pip.rb
+++ b/recipes/pip.rb
@@ -44,7 +44,7 @@ execute "install-pip" do
   # Command updated to only allow pip versions prior to 8.0.0
   # @see https://github.com/DataDog/devops/issues/4225
   command <<-EOF
-  #{node['python']['binary']} get-pip.py --ignore-installed 'pip<8'
+  #{node['python']['binary']} get-pip.py --ignore-installed --no-setuptools 'pip<8'
   EOF
   not_if { ::File.exists?(pip_binary) }
 end


### PR DESCRIPTION
get-pip.py tries to install the latest setuptool that does not support py2. We need to install separately and pin setuptools to <45 version.